### PR TITLE
Per-plugin Configuration

### DIFF
--- a/api/models.graphqls
+++ b/api/models.graphqls
@@ -127,6 +127,7 @@ type Plugin {
   name: PluginName!
   "Whether or not the plugin has been enabled."
   enabled: Boolean!
+  config: Map!
 }
 
 type Route {

--- a/api/mutations.graphqls
+++ b/api/mutations.graphqls
@@ -15,7 +15,7 @@ type Mutation {
   upgradeApp(id: ID!): App!
 
   "Enable one of Miasma's plugins"
-  enablePlugin(name: PluginName!): Plugin!
+  enablePlugin(name: PluginName!, config: Map): Plugin!
   "Disable one of Miasma's plugins"
   disablePlugin(name: PluginName!): Plugin!
 

--- a/internal/cli/cobra/plugin_enable.go
+++ b/internal/cli/cobra/plugin_enable.go
@@ -3,6 +3,7 @@ package cobra
 import (
 	"context"
 
+	"github.com/aklinker1/miasma/internal/cli/flags"
 	"github.com/spf13/cobra"
 )
 
@@ -13,19 +14,22 @@ var pluginEnableCmd = &cobra.Command{
 	Args:      cobra.ExactValidArgs(1),
 	ValidArgs: []string{"TRAEFIK"},
 	Run: func(cmd *cobra.Command, args []string) {
-		enablePlugin(args[0])
+		pluginConfig := flags.GetPluginConfigFlag(cmd)
+		pluginName := args[0]
+		enablePlugin(pluginName, pluginConfig)
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(pluginEnableCmd)
+	flags.UsePluginConfigFlag(pluginEnableCmd)
 }
 
-func enablePlugin(pluginName string) {
+func enablePlugin(pluginName string, pluginConfig map[string]any) {
 	ctx := context.Background()
 	title.Printf("\nEnabling %s...\n", pluginName)
 
-	err := api.EnablePlugin(ctx, pluginName)
+	err := api.EnablePlugin(ctx, pluginName, pluginConfig)
 	checkErr(err)
 
 	done("%s enabled", pluginName)

--- a/internal/cli/flags/auth.go
+++ b/internal/cli/flags/auth.go
@@ -12,11 +12,11 @@ func UseAuthFlag(cmd *cobra.Command) {
 }
 
 func GetAuthFlag(cmd *cobra.Command) string {
-	hidden, err := cmd.Flags().GetString("auth")
+	v, err := cmd.Flags().GetString("auth")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	return hidden
+	return v
 }

--- a/internal/cli/flags/plugin_config.go
+++ b/internal/cli/flags/plugin_config.go
@@ -1,0 +1,27 @@
+package flags
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func UsePluginConfigFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP("plugin-config", "c", "", "JSON string representing the plugin's config. Example: --plugin-config '{ \"key\": \"value\" }'")
+}
+
+func GetPluginConfigFlag(cmd *cobra.Command) map[string]any {
+	v, err := cmd.Flags().GetString("plugin-config")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	config := map[string]any{}
+	if v != "" {
+		json.Unmarshal([]byte(v), &config)
+	}
+	return config
+}

--- a/internal/cli/http/miasma_api_client.go
+++ b/internal/cli/http/miasma_api_client.go
@@ -188,15 +188,16 @@ func (c *MiasmaAPIClient) DisablePlugin(ctx context.Context, pluginName string) 
 }
 
 // EnablePlugin implements cli.APIService
-func (c *MiasmaAPIClient) EnablePlugin(ctx context.Context, pluginName string) error {
+func (c *MiasmaAPIClient) EnablePlugin(ctx context.Context, pluginName string, pluginConfig map[string]any) error {
 	return c.post(
 		ctx,
-		`mutation ($name: PluginName!) {
-			enablePlugin(name: $name) %s
+		`mutation ($name: PluginName!, $config: Map) {
+			enablePlugin(name: $name, config: $config) %s
 		}`,
 		`{ name }`,
 		map[string]any{
-			"name": pluginName,
+			"name":   pluginName,
+			"config": pluginConfig,
 		},
 		"enablePlugin",
 		&internal.Plugin{},

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -38,6 +38,6 @@ type APIService interface {
 	RemoveAppRoute(ctx context.Context, appID string) error
 
 	ListPlugins(ctx context.Context, gql string) ([]internal.Plugin, error)
-	EnablePlugin(ctx context.Context, pluginName string) error
+	EnablePlugin(ctx context.Context, pluginName string, pluginConfig map[string]any) error
 	DisablePlugin(ctx context.Context, pluginName string) error
 }

--- a/internal/models.generated.go
+++ b/internal/models.generated.go
@@ -127,7 +127,8 @@ type Node struct {
 type Plugin struct {
 	Name PluginName `json:"name"`
 	// Whether or not the plugin has been enabled.
-	Enabled bool `json:"enabled"`
+	Enabled bool                   `json:"enabled"`
+	Config  map[string]interface{} `json:"config"`
 }
 
 type Route struct {

--- a/internal/models.go
+++ b/internal/models.go
@@ -6,3 +6,8 @@ type RunningContainer struct {
 	Name  string
 	AppID string
 }
+
+type TraefikConfig struct {
+	EnableHttps bool   `mapstructure:"enableHttps"`
+	CertEmail   string `mapstructure:"certEmail"`
+}

--- a/internal/server/gqlgen/models.generated.go
+++ b/internal/server/gqlgen/models.generated.go
@@ -2034,6 +2034,47 @@ func (ec *executionContext) fieldContext_Plugin_enabled(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _Plugin_config(ctx context.Context, field graphql.CollectedField, obj *internal.Plugin) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Plugin_config(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Config, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(map[string]interface{})
+	fc.Result = res
+	return ec.marshalOMap2map(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Plugin_config(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Plugin",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Map does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Route_appId(ctx context.Context, field graphql.CollectedField, obj *internal.Route) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Route_appId(ctx, field)
 	if err != nil {
@@ -2984,6 +3025,10 @@ func (ec *executionContext) _Plugin(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "config":
+
+			out.Values[i] = ec._Plugin_config(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/server/gqlgen/mutations.generated.go
+++ b/internal/server/gqlgen/mutations.generated.go
@@ -23,7 +23,7 @@ type MutationResolver interface {
 	StopApp(ctx context.Context, id string) (*internal.App, error)
 	RestartApp(ctx context.Context, id string) (*internal.App, error)
 	UpgradeApp(ctx context.Context, id string) (*internal.App, error)
-	EnablePlugin(ctx context.Context, name internal.PluginName) (*internal.Plugin, error)
+	EnablePlugin(ctx context.Context, name internal.PluginName, config map[string]interface{}) (*internal.Plugin, error)
 	DisablePlugin(ctx context.Context, name internal.PluginName) (*internal.Plugin, error)
 	SetAppEnv(ctx context.Context, appID string, newEnv map[string]interface{}) (map[string]interface{}, error)
 	SetAppRoute(ctx context.Context, appID string, route *internal.RouteInput) (*internal.Route, error)
@@ -115,6 +115,15 @@ func (ec *executionContext) field_Mutation_enablePlugin_args(ctx context.Context
 		}
 	}
 	args["name"] = arg0
+	var arg1 map[string]interface{}
+	if tmp, ok := rawArgs["config"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("config"))
+		arg1, err = ec.unmarshalOMap2map(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["config"] = arg1
 	return args, nil
 }
 
@@ -956,7 +965,7 @@ func (ec *executionContext) _Mutation_enablePlugin(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().EnablePlugin(rctx, fc.Args["name"].(internal.PluginName))
+		return ec.resolvers.Mutation().EnablePlugin(rctx, fc.Args["name"].(internal.PluginName), fc.Args["config"].(map[string]interface{}))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -985,6 +994,8 @@ func (ec *executionContext) fieldContext_Mutation_enablePlugin(ctx context.Conte
 				return ec.fieldContext_Plugin_name(ctx, field)
 			case "enabled":
 				return ec.fieldContext_Plugin_enabled(ctx, field)
+			case "config":
+				return ec.fieldContext_Plugin_config(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Plugin", field.Name)
 		},
@@ -1046,6 +1057,8 @@ func (ec *executionContext) fieldContext_Mutation_disablePlugin(ctx context.Cont
 				return ec.fieldContext_Plugin_name(ctx, field)
 			case "enabled":
 				return ec.fieldContext_Plugin_enabled(ctx, field)
+			case "config":
+				return ec.fieldContext_Plugin_config(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Plugin", field.Name)
 		},

--- a/internal/server/gqlgen/queries.generated.go
+++ b/internal/server/gqlgen/queries.generated.go
@@ -405,6 +405,8 @@ func (ec *executionContext) fieldContext_Query_listPlugins(ctx context.Context, 
 				return ec.fieldContext_Plugin_name(ctx, field)
 			case "enabled":
 				return ec.fieldContext_Plugin_enabled(ctx, field)
+			case "config":
+				return ec.fieldContext_Plugin_config(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Plugin", field.Name)
 		},
@@ -455,6 +457,8 @@ func (ec *executionContext) fieldContext_Query_getPlugin(ctx context.Context, fi
 				return ec.fieldContext_Plugin_name(ctx, field)
 			case "enabled":
 				return ec.fieldContext_Plugin_enabled(ctx, field)
+			case "config":
+				return ec.fieldContext_Plugin_config(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Plugin", field.Name)
 		},

--- a/internal/server/graphql/mutations.resolvers.go
+++ b/internal/server/graphql/mutations.resolvers.go
@@ -141,7 +141,7 @@ func (r *mutationResolver) UpgradeApp(ctx context.Context, id string) (*internal
 	return safeReturn(&updated, nil, err)
 }
 
-func (r *mutationResolver) EnablePlugin(ctx context.Context, name internal.PluginName) (*internal.Plugin, error) {
+func (r *mutationResolver) EnablePlugin(ctx context.Context, name internal.PluginName, config map[string]interface{}) (*internal.Plugin, error) {
 	plugin, err := r.Plugins.FindPlugin(ctx, server.PluginsFilter{
 		Name: &name,
 	})
@@ -149,7 +149,7 @@ func (r *mutationResolver) EnablePlugin(ctx context.Context, name internal.Plugi
 		return nil, err
 	}
 
-	updated, err := r.Plugins.EnablePlugin(ctx, plugin)
+	updated, err := r.Plugins.EnablePlugin(ctx, plugin, config)
 	return safeReturn(&updated, nil, err)
 }
 

--- a/internal/server/interfaces.go
+++ b/internal/server/interfaces.go
@@ -83,7 +83,7 @@ type PluginService interface {
 	// FindApp searches the list of built-in plugins for the first plugin that matches the criteria
 	FindPlugin(ctx context.Context, filter PluginsFilter) (internal.Plugin, error)
 	// Enabled a plugin and restart all applications
-	EnablePlugin(ctx context.Context, plugin internal.Plugin) (internal.Plugin, error)
+	EnablePlugin(ctx context.Context, plugin internal.Plugin, config map[string]any) (internal.Plugin, error)
 	// Disable a plugin and restart all applications
 	DisablePlugin(ctx context.Context, plugin internal.Plugin) (internal.Plugin, error)
 }

--- a/internal/server/sqlite/migrations/00005-plugin-config.sql
+++ b/internal/server/sqlite/migrations/00005-plugin-config.sql
@@ -1,0 +1,2 @@
+ALTER TABLE plugins
+ADD "config" blob;

--- a/internal/server/sqlite/plugins_repo.go
+++ b/internal/server/sqlite/plugins_repo.go
@@ -15,6 +15,7 @@ func findPlugins(ctx context.Context, tx server.Tx, filter server.PluginsFilter)
 	query := sqlb.Select("plugins", map[string]any{
 		"name":    sqlitetypes.PluginName(&scanned.Name),
 		"enabled": &scanned.Enabled,
+		"config":  sqlitetypes.JSON(&scanned.Config),
 	})
 	if filter.Name != nil {
 		query.Where("name = ?", *filter.Name)
@@ -59,9 +60,11 @@ func findPlugin(ctx context.Context, tx server.Tx, filter server.PluginsFilter) 
 }
 
 func updatePlugin(ctx context.Context, tx server.Tx, plugin internal.Plugin) (internal.Plugin, error) {
-	sql, args := sqlb.Update("plugins", "name", sqlitetypes.PluginName(plugin.Name), map[string]any{
+	data := map[string]any{
 		"enabled": plugin.Enabled,
-	}).ToSQL()
+		"config":  sqlitetypes.JSON(plugin.Config),
+	}
+	sql, args := sqlb.Update("plugins", "name", sqlitetypes.PluginName(plugin.Name), data).ToSQL()
 	_, err := tx.ExecContext(ctx, sql, args...)
 	return plugin, err
 }

--- a/internal/server/sqlite/sqlitetypes/data_types.go
+++ b/internal/server/sqlite/sqlitetypes/data_types.go
@@ -157,3 +157,41 @@ func (name *pluginName) Scan(src interface{}) error {
 func (name pluginName) Value() (driver.Value, error) {
 	return string(name), nil
 }
+
+// blob -> map[string]any
+
+type jsonBlob map[string]any
+
+func JSON(a any) any {
+	switch a := a.(type) {
+	case map[string]any:
+		return (*jsonBlob)(&a)
+	case *map[string]any:
+		return (*jsonBlob)(a)
+	}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (array jsonBlob) Value() (driver.Value, error) {
+	return json.Marshal(array)
+}
+
+// Scan implements the sql.Scanner interface.
+func (a *jsonBlob) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return json.Unmarshal(src, a)
+	case string:
+		return json.Unmarshal([]byte(src), a)
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return &server.Error{
+		Code:    server.EINTERNAL,
+		Message: fmt.Sprintf("Failed to scan %+v (%T) into a map[string]any", src, src),
+		Op:      "jsonMap.Scan",
+	}
+}


### PR DESCRIPTION
Apart of #30, there needs to be a way to configure plugins so the API supports adding flags like `enableHttps` or `certEmail` for Traefik.

See GraphQL schema changes for details on what this looks like:

https://github.com/aklinker1/miasma/blob/9ed7df98a29db1ad62d5958023c34b55a158d19a/api/mutations.graphqls#L17-L18

https://github.com/aklinker1/miasma/blob/9ed7df98a29db1ad62d5958023c34b55a158d19a/api/models.graphqls#L130

And here's how to configure it from the CLI:

```bash
miasma plugins:enable TRAEFIK --plugin-config '{"certEmail": "<your-email>", "enableHttps": true}'
```

- [x] Support plugin config via API
- [x] Pass config via CLI, for now, as a JSON string.