### PR TITLE
chore(api): require all plugins to start an app

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,28 +22,21 @@ var (
 	ACCESS_TOKEN = os.Getenv("ACCESS_TOKEN")
 )
 
-// Other constants
-var (
-	dataDir          = "/data/miasma"
-	databasePath     = dataDir + "/apps.db"
-	certResolverName = "miasmaresolver"
-)
-
 func main() {
 	logger := &fmt.Logger{}
 
-	db := sqlite.NewDB(databasePath, logger)
+	db := sqlite.NewDB("/data/miasma/apps.db", logger)
 	err := db.Open()
 	if err != nil {
 		logger.E("Failed to open database: %v", err)
 		os.Exit(1)
 	}
 
-	runtime, err := docker.NewRuntimeService(logger, certResolverName)
+	runtime, err := docker.NewRuntimeService(logger)
 	apps := sqlite.NewAppService(db, runtime, logger)
 	env := sqlite.NewEnvService(db, runtime, logger)
 	routes := sqlite.NewRouteService(db, logger)
-	plugins := sqlite.NewPluginService(db, apps, runtime, logger, dataDir, certResolverName)
+	plugins := sqlite.NewPluginService(db, apps, runtime, logger)
 	if err != nil {
 		logger.E("Failed to initialize docker runtime: %v", err)
 		os.Exit(1)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,21 +22,28 @@ var (
 	ACCESS_TOKEN = os.Getenv("ACCESS_TOKEN")
 )
 
+// Other constants
+var (
+	dataDir          = "/data/miasma"
+	databasePath     = dataDir + "/apps.db"
+	certResolverName = "miasmaresolver"
+)
+
 func main() {
 	logger := &fmt.Logger{}
 
-	db := sqlite.NewDB("/data/miasma/apps.db", logger)
+	db := sqlite.NewDB(databasePath, logger)
 	err := db.Open()
 	if err != nil {
 		logger.E("Failed to open database: %v", err)
 		os.Exit(1)
 	}
 
-	runtime, err := docker.NewRuntimeService(logger)
+	runtime, err := docker.NewRuntimeService(logger, certResolverName)
 	apps := sqlite.NewAppService(db, runtime, logger)
 	env := sqlite.NewEnvService(db, runtime, logger)
 	routes := sqlite.NewRouteService(db, logger)
-	plugins := sqlite.NewPluginService(db, apps, runtime, logger)
+	plugins := sqlite.NewPluginService(db, apps, runtime, logger, dataDir, certResolverName)
 	if err != nil {
 		logger.E("Failed to initialize docker runtime: %v", err)
 		os.Exit(1)

--- a/internal/server/docker/runtime_service.go
+++ b/internal/server/docker/runtime_service.go
@@ -228,7 +228,7 @@ func (s *RuntimeService) getServiceSpec(ctx context.Context, app internal.App, r
 	traefikPlugin, ok := lo.Find(plugins, func(plugin internal.Plugin) bool {
 		return plugin.Name == internal.PluginNameTraefik
 	})
-	if ok && route != nil && traefikPlugin.Enabled {
+	if ok && traefikPlugin.Enabled && route != nil {
 		labels["traefik.enable"] = "true"
 		labels["traefik.docker.network"] = s.getNetworkName(defaultNetwork)
 		labels["traefik.http.services."+name+"-service.loadbalancer.server.port"] = fmt.Sprint(ports[0].TargetPort)

--- a/internal/server/graphql/mutations.resolvers.go
+++ b/internal/server/graphql/mutations.resolvers.go
@@ -51,7 +51,12 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input internal.AppInpu
 		Command:  input.Command,
 	}
 
-	created, err := r.Apps.Create(ctx, a)
+	plugins, err := r.Plugins.FindPlugins(ctx, server.PluginsFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := r.Apps.Create(ctx, a, plugins)
 	return safeReturn(&created, nil, err)
 }
 
@@ -100,7 +105,12 @@ func (r *mutationResolver) StartApp(ctx context.Context, id string) (*internal.A
 		return nil, err
 	}
 
-	err = r.Runtime.Start(ctx, app, route, env)
+	plugins, err := r.Plugins.FindPlugins(ctx, server.PluginsFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.Runtime.Start(ctx, app, route, env, plugins)
 	return safeReturn(&app, nil, err)
 }
 
@@ -127,8 +137,12 @@ func (r *mutationResolver) RestartApp(ctx context.Context, id string) (*internal
 	if err != nil {
 		return nil, err
 	}
+	plugins, err := r.Plugins.FindPlugins(ctx, server.PluginsFilter{})
+	if err != nil {
+		return nil, err
+	}
 
-	err = r.Runtime.Restart(ctx, app, route, env)
+	err = r.Runtime.Restart(ctx, app, route, env, plugins)
 	return safeReturn(&app, nil, err)
 }
 

--- a/internal/server/interfaces.go
+++ b/internal/server/interfaces.go
@@ -60,7 +60,7 @@ type AppsFilter struct {
 
 type AppService interface {
 	// Create and start a new app
-	Create(ctx context.Context, app internal.App) (internal.App, error)
+	Create(ctx context.Context, app internal.App, plugins []internal.Plugin) (internal.App, error)
 	// FindApps searches the list of managed applications
 	FindApps(ctx context.Context, filter AppsFilter) ([]internal.App, error)
 	// FindApp searches the list of managed applications for the first app that matches the criteria
@@ -95,9 +95,10 @@ type RuntimeAppInfo struct {
 }
 
 type StartAppParams struct {
-	App   internal.App
-	Route *internal.Route
-	Env   internal.EnvMap
+	App     internal.App
+	Route   *internal.Route
+	Env     internal.EnvMap
+	Plugins []internal.Plugin
 }
 
 type ListServicesFilter struct {
@@ -107,11 +108,11 @@ type ListServicesFilter struct {
 // RuntimeService defines how the server runs the apps
 type RuntimeService interface {
 	// Start the app
-	Start(ctx context.Context, app internal.App, route *internal.Route, env map[string]string) error
+	Start(ctx context.Context, app internal.App, route *internal.Route, env map[string]string, plugins []internal.Plugin) error
 	// ServiceDetails returns runtime details like instance count and status
 	GetRuntimeAppInfo(ctx context.Context, app internal.App) (RuntimeAppInfo, error)
 	// Restart stops and starts the app
-	Restart(ctx context.Context, app internal.App, route *internal.Route, env map[string]string) error
+	Restart(ctx context.Context, app internal.App, route *internal.Route, env map[string]string, plugins []internal.Plugin) error
 	// Stop stops the app if it's running
 	Stop(ctx context.Context, app internal.App) error
 	// PullLatest grabs the latest image and returns it's digest

--- a/internal/server/sqlite/env_service.go
+++ b/internal/server/sqlite/env_service.go
@@ -68,14 +68,14 @@ func (s *EnvService) SetAppEnv(ctx context.Context, appID string, newEnv interna
 	}
 
 	// Restart the app
-	app, route, _, err := findStartParams(ctx, tx, appID, startParamKnowns{
+	app, route, _, plugins, err := findStartParams(ctx, tx, appID, startParamKnowns{
 		env:      newEnv,
 		knownEnv: true,
 	})
 	if err != nil {
 		return EmptyEnvMap, err
 	}
-	err = s.runtime.Restart(ctx, app, route, newEnv)
+	err = s.runtime.Restart(ctx, app, route, newEnv, plugins)
 	if err != nil {
 		return EmptyEnvMap, err
 	}

--- a/internal/server/sqlite/plugin_service.go
+++ b/internal/server/sqlite/plugin_service.go
@@ -39,6 +39,7 @@ func (s *PluginService) getTraefikApp(config map[string]any) (internal.App, erro
 
 	command := []string{"traefik"}
 	if traefikConfig.EnableHttps {
+		s.logger.W("TLS/HTTPS is not implemented yet")
 		if traefikConfig.CertEmail == "" {
 			return EmptyApp, &server.Error{
 				Code:    server.EINVALID,
@@ -46,8 +47,10 @@ func (s *PluginService) getTraefikApp(config map[string]any) (internal.App, erro
 				Op:      "sqlite.PluginService.traefikApp",
 			}
 		}
+	} else {
+		command = append(command, "--api.insecure=true")
 	}
-	command = append(command, "--api.insecure=true", "--api.insecure=true", "--providers.docker", "--providers.docker.swarmmode")
+	command = append(command, "--providers.docker", "--providers.docker.swarmmode")
 
 	return internal.App{
 		ID:             "plugin-traefik",


### PR DESCRIPTION
For #30, we'll need the full traefik plugin to decide whether or not to add the TLS labels to the docker service. This just refactors the code to support passing all plugins into the `docker.RuntimeService.getServiceSpec` method.